### PR TITLE
fix: Spelling

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -3,7 +3,7 @@ import { vec3, mat4 } from "gl-matrix";
 
 /*
 SVG transform attr is a bit strange in that it can accept traditional
-css transform string (at least per spec) as well as a it's own "unitless"
+css transform string (at least per spec) as well as its own "unitless"
 version of transform functions.
 
 https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -116,7 +116,7 @@ const svgTransformToCSSTransform = (svgTransformStr: string): string => {
   });
 
   // Generate a string of transform functions that can be set as a CSS Transform.
-  const csstransformStr = tFuncValues
+  const cssTransformStr = tFuncValues
     .map(({ type, values }) => {
       const valStr = values
         .map(({ unit, value }) => `${value}${unit}`)
@@ -125,7 +125,7 @@ const svgTransformToCSSTransform = (svgTransformStr: string): string => {
     })
     .join(" ");
 
-  return csstransformStr;
+  return cssTransformStr;
 };
 
 export const createDOMMatrixFromSVGStr = (

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -71,7 +71,7 @@ const presAttrs = (
 };
 
 const skippedUseAttrs = ["id"];
-const allwaysPassedUseAttrs = [
+const alwaysPassedUseAttrs = [
   "x",
   "y",
   "width",
@@ -104,7 +104,7 @@ const getDefElWithCorrectAttrs = (defEl: Element, useEl: Element): Element => {
     // Does defEl have the attr? If so, use it, else use the useEl attr
     if (
       !defEl.hasAttribute(attr.name) ||
-      allwaysPassedUseAttrs.includes(attr.name)
+      alwaysPassedUseAttrs.includes(attr.name)
     ) {
       el.setAttribute(attr.name, useEl.getAttribute(attr.name) || "");
     }


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling)

The misspellings have been reported at https://github.com/jsoref/svg-to-excalidraw/actions/runs/18960465211/attempts/1#summary-54146463721

The action reports that the changes in this PR would make it mostly happy: https://github.com/jsoref/svg-to-excalidraw/actions/runs/18960465249/attempts/1#summary-54146463816